### PR TITLE
Fix toon shaders to get the game work with last version of superpowers.

### DIFF
--- a/assets/In-Game (196)/Enemies (68)/Prefabs (389)/Black (390)/scene.json
+++ b/assets/In-Game (196)/Enemies (68)/Prefabs (389)/Black (390)/scene.json
@@ -43,8 +43,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Enemies (68)/Prefabs (389)/White (73)/scene.json
+++ b/assets/In-Game (196)/Enemies (68)/Prefabs (389)/White (73)/scene.json
@@ -43,8 +43,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Game Scene (9)/scene.json
+++ b/assets/In-Game (196)/Game Scene (9)/scene.json
@@ -74,7 +74,6 @@
                       "height": 2048
                     },
                     "shadowBias": -0.002,
-                    "shadowDarkness": 0.5,
                     "shadowCameraNearPlane": 0.1,
                     "shadowCameraFarPlane": 20,
                     "shadowCameraFov": 50,
@@ -84,7 +83,7 @@
                       "left": -20,
                       "right": 20
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2
                   },
                   "id": "0"
                 }
@@ -133,7 +132,11 @@
                   "x": 0,
                   "y": 0
                 },
-                "formatVersion": 1
+                "formatVersion": 2,
+                "bounce": {
+                  "x": 0,
+                  "y": 0
+                }
               },
               "id": "1"
             }

--- a/assets/In-Game (196)/Rooms (71)/Bathroom (223)/Bathroom (251)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Bathroom (223)/Bathroom (251)/scene.json
@@ -548,7 +548,11 @@
                       "x": 3.5,
                       "y": -6
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "0"
                 }
@@ -612,7 +616,11 @@
                           "x": 0,
                           "y": 1
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -672,7 +680,11 @@
                           "x": 0,
                           "y": 1
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }

--- a/assets/In-Game (196)/Rooms (71)/Cafeteria (219)/Cafeteria (229)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Cafeteria (219)/Cafeteria (229)/scene.json
@@ -434,7 +434,11 @@
                           "x": -0.05,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "0"
                     }
@@ -491,7 +495,11 @@
                       "x": -1.2,
                       "y": -0.9
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -597,7 +605,11 @@
                           "x": 2.3,
                           "y": 0.5
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -704,7 +716,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -764,7 +780,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -824,7 +844,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -884,7 +908,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -941,7 +969,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1005,7 +1037,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1065,7 +1101,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1125,7 +1165,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1185,7 +1229,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1242,7 +1290,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1306,7 +1358,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1366,7 +1422,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1426,7 +1486,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1486,7 +1550,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1543,7 +1611,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1607,7 +1679,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1667,7 +1743,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1727,7 +1807,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1787,7 +1871,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1844,7 +1932,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1908,7 +2000,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -1968,7 +2064,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2028,7 +2128,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2088,7 +2192,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2145,7 +2253,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2209,7 +2321,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2269,7 +2385,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2329,7 +2449,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2389,7 +2513,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2446,7 +2574,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2510,7 +2642,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2570,7 +2706,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2630,7 +2770,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2690,7 +2834,11 @@
                               "x": 0,
                               "y": 0.1
                             },
-                            "formatVersion": 1
+                            "formatVersion": 2,
+                            "bounce": {
+                              "x": 0,
+                              "y": 0
+                            }
                           },
                           "id": "1"
                         }
@@ -2747,7 +2895,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }

--- a/assets/In-Game (196)/Rooms (71)/Cafeteria (219)/Granny (281)/BeatJuiceBoy Prefab (255)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Cafeteria (219)/Granny (281)/BeatJuiceBoy Prefab (255)/scene.json
@@ -59,8 +59,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Classroom (213)/Classroom (214)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Classroom (213)/Classroom (214)/scene.json
@@ -332,7 +332,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "2"
                     }
@@ -392,7 +396,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -452,7 +460,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -512,7 +524,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -572,7 +588,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -632,7 +652,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -692,7 +716,11 @@
                           "x": 0,
                           "y": 0.1
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -752,7 +780,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -838,7 +870,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -898,7 +934,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -958,7 +998,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1060,7 +1104,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1120,7 +1168,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1180,7 +1232,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1240,7 +1296,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1364,7 +1424,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1424,7 +1488,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1694,7 +1762,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Classroom (213)/Granny (323)/Teacher Prefab (326)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Classroom (213)/Granny (323)/Teacher Prefab (326)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Entrance (193)/Entrance (194)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Entrance (193)/Entrance (194)/scene.json
@@ -1528,7 +1528,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "0"
                     },
@@ -1757,7 +1761,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1817,7 +1825,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1877,7 +1889,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1937,7 +1953,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1997,7 +2017,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2057,7 +2081,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2117,7 +2145,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2177,7 +2209,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2263,7 +2299,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2323,7 +2363,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2383,7 +2427,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2443,7 +2491,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2503,7 +2555,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2563,7 +2619,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2623,7 +2683,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2683,7 +2747,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2743,7 +2811,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }

--- a/assets/In-Game (196)/Rooms (71)/Laboratory (221)/Birthday (306)/Beatrice Prefab (307)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Laboratory (221)/Birthday (306)/Beatrice Prefab (307)/scene.json
@@ -35,8 +35,12 @@
                 "tileMapAssetId": null,
                 "tileSetPropertyName": null,
                 "layersIndex": null,
-                "formatVersion": 1,
+                "formatVersion": 2,
                 "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "bounce": {
                   "x": 0,
                   "y": 0
                 }

--- a/assets/In-Game (196)/Rooms (71)/Laboratory (221)/Laboratory (236)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Laboratory (221)/Laboratory (236)/scene.json
@@ -699,7 +699,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "0"
                 }
@@ -996,7 +1000,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "0"
                 }
@@ -3292,7 +3300,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -3352,7 +3364,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -3538,7 +3554,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Left Corridor (203)/Granny (279)/JuiceGumBoy Prefab (234)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Left Corridor (203)/Granny (279)/JuiceGumBoy Prefab (234)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Left Corridor (203)/Left Corridor (204)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Left Corridor (203)/Left Corridor (204)/scene.json
@@ -1208,7 +1208,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1272,7 +1276,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1332,7 +1340,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1392,7 +1404,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1452,7 +1468,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1512,7 +1532,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1572,7 +1596,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1632,7 +1660,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1692,7 +1724,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1752,7 +1788,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -2071,7 +2111,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -2174,7 +2218,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -2277,7 +2325,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Library (217)/Library (227)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Library (217)/Library (227)/scene.json
@@ -523,7 +523,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -583,7 +587,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -643,7 +651,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -703,7 +715,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -763,7 +779,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -823,7 +843,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -883,7 +907,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -943,7 +971,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1003,7 +1035,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1063,7 +1099,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1123,7 +1163,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1183,7 +1227,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1243,7 +1291,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1303,7 +1355,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1363,7 +1419,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1423,7 +1483,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1483,7 +1547,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1543,7 +1611,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1603,7 +1675,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1675,7 +1751,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "0"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Library (217)/Monster (278)/Gaetan Prefab (285)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Library (217)/Monster (278)/Gaetan Prefab (285)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Library (217)/Monster (278)/Teacher Prefab (288)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Library (217)/Monster (278)/Teacher Prefab (288)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Library (217)/Monster (278)/Whining Prefab (276)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Library (217)/Monster (278)/Whining Prefab (276)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Library (217)/Watering Can Prefab (310)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Library (217)/Watering Can Prefab (310)/scene.json
@@ -97,9 +97,13 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
               "x": 0.1,
+              "y": 0
+            },
+            "bounce": {
+              "x": 0,
               "y": 0
             }
           },

--- a/assets/In-Game (196)/Rooms (71)/Locker Room (226)/Locker Room (258)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Locker Room (226)/Locker Room (258)/scene.json
@@ -361,7 +361,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -464,7 +468,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -567,7 +575,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -670,7 +682,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -773,7 +789,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -876,7 +896,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -979,7 +1003,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1039,7 +1067,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1141,7 +1173,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1201,7 +1237,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1261,7 +1301,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1321,7 +1365,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1381,7 +1429,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1441,7 +1493,11 @@
                       "x": -0.25,
                       "y": -0.9
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1501,7 +1557,11 @@
                       "x": -0.25,
                       "y": -1.2
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1561,7 +1621,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1621,7 +1685,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Locker Room (226)/Monster (330)/Ball Prefab (371)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Locker Room (226)/Monster (330)/Ball Prefab (371)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Locker Room (226)/Monster (330)/Jeremy Prefab (333)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Locker Room (226)/Monster (330)/Jeremy Prefab (333)/scene.json
@@ -44,8 +44,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Playground (220)/Birthday (291)/Gaetan Prefab (298)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Playground (220)/Birthday (291)/Gaetan Prefab (298)/scene.json
@@ -35,8 +35,12 @@
                 "tileMapAssetId": null,
                 "tileSetPropertyName": null,
                 "layersIndex": null,
-                "formatVersion": 1,
+                "formatVersion": 2,
                 "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "bounce": {
                   "x": 0,
                   "y": 0
                 }

--- a/assets/In-Game (196)/Rooms (71)/Playground (220)/Flowers (378)/Magalie Prefab (381)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Playground (220)/Flowers (378)/Magalie Prefab (381)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Playground (220)/Granny (293)/DealerBoy Prefab (303)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Playground (220)/Granny (293)/DealerBoy Prefab (303)/scene.json
@@ -31,8 +31,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Rooms (71)/Playground (220)/Playground (231)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Playground (220)/Playground (231)/scene.json
@@ -662,7 +662,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -722,7 +726,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -782,7 +790,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -842,7 +854,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -902,7 +918,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -962,7 +982,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1022,7 +1046,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1082,7 +1110,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1142,7 +1174,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1202,7 +1238,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1262,7 +1302,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1322,7 +1366,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1382,7 +1430,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1442,7 +1494,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Principal's Office (222)/Principal's Office (239)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Principal's Office (222)/Principal's Office (239)/scene.json
@@ -163,7 +163,11 @@
                       "x": 0,
                       "y": 0.3
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "2"
                 }
@@ -519,7 +523,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -579,7 +587,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -639,7 +651,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -741,7 +757,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -801,7 +821,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -861,7 +885,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -921,7 +949,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -981,7 +1013,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1195,7 +1231,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Principal's Private Room (224)/Principal's Private Room (248)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Principal's Private Room (224)/Principal's Private Room (248)/scene.json
@@ -407,7 +407,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -467,7 +471,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -527,7 +535,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -587,7 +599,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -647,7 +663,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -707,7 +727,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -767,7 +791,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -827,7 +855,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1022,7 +1054,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Rooms (71)/Right Corridor (207)/Birthday (294)/Clea Prefab (292)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Right Corridor (207)/Birthday (294)/Clea Prefab (292)/scene.json
@@ -35,8 +35,12 @@
                 "tileMapAssetId": null,
                 "tileSetPropertyName": null,
                 "layersIndex": null,
-                "formatVersion": 1,
+                "formatVersion": 2,
                 "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "bounce": {
                   "x": 0,
                   "y": 0
                 }

--- a/assets/In-Game (196)/Rooms (71)/Right Corridor (207)/Right Corridor (208)/scene.json
+++ b/assets/In-Game (196)/Rooms (71)/Right Corridor (207)/Right Corridor (208)/scene.json
@@ -1100,7 +1100,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1160,7 +1164,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1220,7 +1228,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1280,7 +1292,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1340,7 +1356,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1400,7 +1420,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1460,7 +1484,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1520,7 +1548,11 @@
                           "x": 0,
                           "y": 0
                         },
-                        "formatVersion": 1
+                        "formatVersion": 2,
+                        "bounce": {
+                          "x": 0,
+                          "y": 0
+                        }
                       },
                       "id": "1"
                     }
@@ -1645,7 +1677,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1748,7 +1784,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1851,7 +1891,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }
@@ -1954,7 +1998,11 @@
                       "x": 0,
                       "y": 0
                     },
-                    "formatVersion": 1
+                    "formatVersion": 2,
+                    "bounce": {
+                      "x": 0,
+                      "y": 0
+                    }
                   },
                   "id": "1"
                 }

--- a/assets/In-Game (196)/Scenery (15)/Library (355)/Flower In Pot (359)/scene.json
+++ b/assets/In-Game (196)/Scenery (15)/Library (355)/Flower In Pot (359)/scene.json
@@ -74,8 +74,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/In-Game (196)/Scenery (15)/Playground (131)/Plants (186)/Tree Pref (189)/scene.json
+++ b/assets/In-Game (196)/Scenery (15)/Playground (131)/Plants (186)/Tree Pref (189)/scene.json
@@ -74,8 +74,12 @@
             "tileMapAssetId": null,
             "tileSetPropertyName": null,
             "layersIndex": null,
-            "formatVersion": 1,
+            "formatVersion": 2,
             "offset": {
+              "x": 0,
+              "y": 0
+            },
+            "bounce": {
               "x": 0,
               "y": 0
             }

--- a/assets/Shaders (26)/Toon Shading (120)/fragmentShader.txt
+++ b/assets/Shaders (26)/Toon Shading (120)/fragmentShader.txt
@@ -8,6 +8,7 @@ uniform vec3 color;
 #include <common>
 #include <bsdfs>
 #include <lights_pars>
+#include <packing>
 #include <shadowmap_pars_fragment>
 
 uniform float shadow1Value;

--- a/assets/Shaders (26)/Toon Shading Bend (188)/fragmentShader.txt
+++ b/assets/Shaders (26)/Toon Shading Bend (188)/fragmentShader.txt
@@ -8,6 +8,7 @@ uniform vec3 color;
 #include <common>
 #include <bsdfs>
 #include <lights_pars>
+#include <packing>
 #include <shadowmap_pars_fragment>
 
 uniform float shadow1Value;


### PR DESCRIPTION
Fat kevin was not working with Superpowers v4.0.0. The problem was that unpackRGBAToDepth() function declaration was not found.
Since unpackRGBAToDepth() is declared in packing, we had to add packing in shaders declaration assets.